### PR TITLE
`kill-emacs-query-functions` hook now uses async version of `livedown…

### DIFF
--- a/livedown.el
+++ b/livedown.el
@@ -54,16 +54,17 @@
                             (if livedown:open "--open" "")))
         (print (format "%s rendered @ %s" buffer-file-name livedown:port) (get-buffer "emacs-livedown-buffer")))
 
-(defun livedown:kill ()
+(defun livedown:kill (&optional async)
     "Stops the livedown process."
       (interactive)
-        (call-process-shell-command
+        (setq stop-livedown (if async 'async-shell-command 'call-process-shell-command))
+        (funcall stop-livedown
              (format "livedown stop --port %s &"
                             livedown:port)))
 
 (if livedown:autostart
   (eval-after-load 'markdown-mode '(livedown:preview)))
 
-(add-hook 'kill-emacs-query-functions (lambda () (livedown:kill)))
+(add-hook 'kill-emacs-query-functions (lambda () (livedown:kill t)))
 
 (provide 'livedown)


### PR DESCRIPTION
Hi @shime. Thx for the great work you have done with the plugin so far. I'm using it almost everyday. I introduced a little improvement for the exit hook. The hook now uses async version of `livedown:kill`. It eliminates annoying delay on Windows platform (about 2 secs) while exiting EMACS and _livedown_ process is no longer running or was not started at all.
