### PR TITLE
Use standard emacs namespacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ This plugin uses some configurable variables, with the following defaults
 
 ```elisp
 (custom-set-variables
- '(livedown:autostart nil) ; automatically open preview when opening markdown files 
- '(livedown:open t)        ; automatically open the browser window
- '(livedown:port 1337)     ; port for livedown server
- '(livedown:browser nil))  ; browser to use
+ '(livedown-autostart nil) ; automatically open preview when opening markdown files
+ '(livedown-open t)        ; automatically open the browser window
+ '(livedown-port 1337)     ; port for livedown server
+ '(livedown-browser nil))  ; browser to use
 ```
 
 Make sure to place them before the `require` line in your `init.el`.
@@ -39,14 +39,14 @@ Make sure to place them before the `require` line in your `init.el`.
 You can also call the functions manually with
 
 ```elisp
-M-x livedown:preview
-M-x livedown:kill
+M-x livedown-preview
+M-x livedown-kill
 ```
 
 Or for bonus points, define a keybinding with
 
 ```elisp
-(global-set-key (kbd "C-M-m") 'livedown:preview)
+(global-set-key (kbd "C-M-m") 'livedown-preview)
 ```
 
 ## License

--- a/livedown.el
+++ b/livedown.el
@@ -16,58 +16,58 @@
 (defgroup livedown nil
   "Realtime Markdown previews"
   :group 'livedown
-  :prefix "livedown:")
+  :prefix "livedown-")
 
-(defcustom livedown:port 1337
+(defcustom livedown-port 1337
   "Port on which livedown server will run."
   :type 'integer
   :group 'livedown)
 
-(defcustom livedown:open t
+(defcustom livedown-open t
   "Open browser automatically."
   :type 'boolean
   :group 'livedown)
 
-(defcustom livedown:browser nil
+(defcustom livedown-browser nil
   "Open alternative browser."
   :type 'string
   :group 'livedown)
 
-(defcustom livedown:autostart nil
+(defcustom livedown-autostart nil
   "Auto-open previews when opening markdown files."
   :type 'boolean
   :group 'livedown)
 
-(defun livedown:preview ()
+(defun livedown-preview ()
     "Preview the current file in livedown."
     (interactive)
 
    (call-process-shell-command
              (format "livedown stop --port %s &"
-                            livedown:port))
+                            livedown-port))
 
         (start-process-shell-command
             (format "emacs-livedown")
             (format "emacs-livedown-buffer")
             (format "livedown start %s --port %s %s %s "
                             buffer-file-name
-                            livedown:port
-                            (if livedown:browser (concat "--browser " livedown:browser) "")
-                            (if livedown:open "--open" "")))
-        (print (format "%s rendered @ %s" buffer-file-name livedown:port) (get-buffer "emacs-livedown-buffer")))
+                            livedown-port
+                            (if livedown-browser (concat "--browser " livedown-browser) "")
+                            (if livedown-open "--open" "")))
+        (print (format "%s rendered @ %s" buffer-file-name livedown-port) (get-buffer "emacs-livedown-buffer")))
 
-(defun livedown:kill (&optional async)
+(defun livedown-kill (&optional async)
   "Stops the livedown process."
   (interactive)
   (let ((stop-livedown (if async 'async-shell-command 'call-process-shell-command)))
     (funcall stop-livedown
              (format "livedown stop --port %s &"
-                     livedown:port))))
+                     livedown-port))))
 
-(if livedown:autostart
-  (eval-after-load 'markdown-mode '(livedown:preview)))
+(if livedown-autostart
+  (eval-after-load 'markdown-mode '(livedown-preview)))
 
-(add-hook 'kill-emacs-query-functions (lambda () (livedown:kill t)))
+(add-hook 'kill-emacs-query-functions (lambda () (livedown-kill t)))
 
 (provide 'livedown)
 ;;; livedown.el ends here


### PR DESCRIPTION
Using a dash is traditionally how packages are namespaced. Changing it will help with discoverability.
