### PR TITLE
Fix problem reported in original issue #10 to accommodate white space in file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Or for bonus points, define a keybinding with
 (global-set-key (kbd "C-M-m") 'livedown-preview)
 ```
 
+For additional bonus points, open the preview using the browser with custom command line options
+
+```elisp
+(custom-set-variables
+ '(livedown-browser "'firefox -P livedown --private-window'"))  ; browser to use with custom options
+```
+
+
 ## License
 
 MIT

--- a/livedown.el
+++ b/livedown.el
@@ -50,7 +50,7 @@
         (start-process-shell-command
             (format "emacs-livedown")
             (format "emacs-livedown-buffer")
-            (format "livedown start %s --port %s %s %s "
+            (format "livedown start '%s' --port %s %s %s "
                             buffer-file-name
                             livedown-port
                             (if livedown-browser (concat "--browser " livedown-browser) "")


### PR DESCRIPTION
A simple change to wrap the target file name in quotes resolves this reported issue on my Linux system.